### PR TITLE
Fix Hostinger deploy workflow marker handling

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      force_full_upload:
+        description: "Upload all non-ignored files instead of only Git diff changes"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   deploy:
@@ -24,19 +30,20 @@ jobs:
       - name: Configure deploy ignores
         run: |
           {
-            echo ".git*"
-            echo ".git*/**"
+            echo ".git/"
+            echo ".git/**"
             echo "node_modules/"
             echo ".github/"
             echo "README.md"
             echo ".git-ftp-ignore"
           } > .git-ftp-ignore
 
-      - name: Deploy changed files to Hostinger
+      - name: Deploy files to Hostinger
         env:
           FTP_SERVER: ${{ secrets.FTP_SERVER }}
           FTP_USERNAME: ${{ secrets.FTP_USERNAME }}
           FTP_PASSWORD: ${{ secrets.FTP_PASSWORD }}
+          FORCE_FULL_UPLOAD: ${{ github.event_name == 'workflow_dispatch' && inputs.force_full_upload }}
         run: |
           set -euo pipefail
 
@@ -52,11 +59,18 @@ jobs:
           COMMON_ARGS=(--user "${FTP_USERNAME}" --passwd "${FTP_PASSWORD}" --syncroot "." "${FTP_URL}")
           REMOTE_SHA="$(git ftp show "${COMMON_ARGS[@]}" 2>/dev/null | tail -n 1 | tr -d '[:space:]' || true)"
 
+          if [ "${FORCE_FULL_UPLOAD}" = "true" ]; then
+            echo "Force full upload requested. Uploading every non-ignored file."
+            git ftp push --all "${COMMON_ARGS[@]}"
+            echo "Forced full deployment completed."
+            exit 0
+          fi
+
           if [ -z "${REMOTE_SHA}" ]; then
             echo "No git-ftp deployment marker found on the server."
-            echo "Assuming the site is already uploaded. Recording ${GITHUB_SHA} as deployed without uploading files."
-            git ftp catchup "${COMMON_ARGS[@]}"
-            echo "Catchup completed. This run created the deployment log only."
+            echo "Uploading all non-ignored files and creating the deployment marker."
+            git ftp init "${COMMON_ARGS[@]}"
+            echo "Initial full deployment completed."
             exit 0
           fi
 


### PR DESCRIPTION
## Summary
- Fixes Hostinger deploy workflow so a missing `git-ftp` marker uploads files instead of only recording a catch-up marker.
- Narrows `.git-ftp-ignore` from broad `.git*` patterns to `.git/` and `.git/**`, avoiding accidental ignore of git-ftp deployment metadata.
- Adds a manual `force_full_upload` workflow input for one-time full redeploys from GitHub Actions.

## Root cause
The latest deploy run was green but production stayed stale. Workflow logs showed:

```text
No git-ftp deployment marker found on the server.
Assuming the site is already uploaded.
Recording ... as deployed without uploading files.
```

That means PR #26 was marked deployed without uploading changed files to Hostinger.

## Verification
- YAML parsed successfully locally.
- `git diff --check` passed.
- Branch push now succeeds with workflow permission.

## After merge
Run **Actions → Deploy to Hostinger → Run workflow → main → force_full_upload=true** once, then verify live redirects/assets.
