### PR TITLE
Improve Hostinger FTP passive mode compatibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
               ;;
           esac
 
-          COMMON_ARGS=(--user "${FTP_USERNAME}" --passwd "${FTP_PASSWORD}" --syncroot "." "${FTP_URL}")
+          COMMON_ARGS=(--user "${FTP_USERNAME}" --passwd "${FTP_PASSWORD}" --syncroot "." --disable-epsv "${FTP_URL}")
           REMOTE_SHA="$(git ftp show "${COMMON_ARGS[@]}" 2>/dev/null | tail -n 1 | tr -d '[:space:]' || true)"
 
           if [ "${FORCE_FULL_UPLOAD}" = "true" ]; then


### PR DESCRIPTION
## Summary
- Adds `--disable-epsv` to `git-ftp` calls for Hostinger FTP compatibility.

## Why
The fixed deploy workflow now correctly attempts a full upload, but `git ftp init` fails after ~2 minutes with:

```text
fatal: Can't access remote. Network down? Wrong URL? exiting...
```

That pattern is commonly caused by FTP passive/EPSV incompatibility on shared hosting. Disabling EPSV makes curl/git-ftp fall back to PASV.

## Verification
- Workflow YAML parsed locally.
- `git diff --check` passed.

## After merge
Re-run **Actions → Deploy to Hostinger**. If it still fails, the next likely cause is incorrect `FTP_SERVER` path/host or FTP account access in GitHub Actions secrets.
