### PR TITLE
Use full Hostinger uploads after stale git-ftp marker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,24 +57,8 @@ jobs:
           esac
 
           COMMON_ARGS=(--user "${FTP_USERNAME}" --passwd "${FTP_PASSWORD}" --syncroot "." --disable-epsv "${FTP_URL}")
-          REMOTE_SHA="$(git ftp show "${COMMON_ARGS[@]}" 2>/dev/null | tail -n 1 | tr -d '[:space:]' || true)"
 
-          if [ "${FORCE_FULL_UPLOAD}" = "true" ]; then
-            echo "Force full upload requested. Uploading every non-ignored file."
-            git ftp push --all "${COMMON_ARGS[@]}"
-            echo "Forced full deployment completed."
-            exit 0
-          fi
-
-          if [ -z "${REMOTE_SHA}" ]; then
-            echo "No git-ftp deployment marker found on the server."
-            echo "Uploading all non-ignored files and creating the deployment marker."
-            git ftp init "${COMMON_ARGS[@]}"
-            echo "Initial full deployment completed."
-            exit 0
-          fi
-
-          echo "Found remote deployment marker at commit ${REMOTE_SHA}."
-          echo "Uploading only files changed since the recorded deployment."
-          git ftp push "${COMMON_ARGS[@]}"
-          echo "Incremental deployment completed."
+          echo "Uploading all non-ignored files to Hostinger."
+          echo "Using a full upload because the previous git-ftp catchup marker recorded commits without uploading files."
+          git ftp push --all "${COMMON_ARGS[@]}"
+          echo "Full deployment completed."


### PR DESCRIPTION
## Summary
- Simplifies the Hostinger deploy step to perform a full `git ftp push --all` on every run.
- Keeps `--disable-epsv` from PR #28 for Hostinger passive FTP compatibility.
- Removes the broken `git ftp show`/`init` branching that mis-detected the remote marker.

## Why
The previous run failed fast with:

```text
fatal: Commit found, use 'git ftp push' to sync. Exiting...
```

That means the remote marker exists, but the workflow still chose `git ftp init` because marker detection was unreliable. Also, an earlier `catchup` recorded PR #26 as deployed without uploading files, so an incremental push would not repair production. A full upload is the safest correction.

## Verification
- Workflow YAML parsed locally.
- `git diff --check` passed.

## Expected effect after merge
The push-triggered deploy should upload all non-ignored files to Hostinger, including PR #26 changes: `.htaccess`, `robots.txt`, and `assets/site.min.js`.
