### PR TITLE
Restore incremental Hostinger deploys with marker repair

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,11 +6,11 @@ on:
       - main
   workflow_dispatch:
     inputs:
-      force_full_upload:
-        description: "Upload all non-ignored files instead of only Git diff changes"
+      repair_deploy_marker_to_commit:
+        description: "Optional: set Hostinger git-ftp marker to this deployed commit before incremental push"
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: ""
 
 jobs:
   deploy:
@@ -43,7 +43,7 @@ jobs:
           FTP_SERVER: ${{ secrets.FTP_SERVER }}
           FTP_USERNAME: ${{ secrets.FTP_USERNAME }}
           FTP_PASSWORD: ${{ secrets.FTP_PASSWORD }}
-          FORCE_FULL_UPLOAD: ${{ github.event_name == 'workflow_dispatch' && inputs.force_full_upload }}
+          REPAIR_DEPLOY_MARKER_TO_COMMIT: ${{ github.event_name == 'workflow_dispatch' && inputs.repair_deploy_marker_to_commit || '' }}
         run: |
           set -euo pipefail
 
@@ -58,7 +58,12 @@ jobs:
 
           COMMON_ARGS=(--user "${FTP_USERNAME}" --passwd "${FTP_PASSWORD}" --syncroot "." --disable-epsv "${FTP_URL}")
 
-          echo "Uploading all non-ignored files to Hostinger."
-          echo "Using a full upload because the previous git-ftp catchup marker recorded commits without uploading files."
-          git ftp push --all "${COMMON_ARGS[@]}"
-          echo "Full deployment completed."
+          if [ -n "${REPAIR_DEPLOY_MARKER_TO_COMMIT}" ]; then
+            echo "Repairing git-ftp marker to known deployed commit ${REPAIR_DEPLOY_MARKER_TO_COMMIT}."
+            echo "No site files are uploaded by catchup; the following push uploads only files changed after that commit."
+            git ftp catchup --commit "${REPAIR_DEPLOY_MARKER_TO_COMMIT}" "${COMMON_ARGS[@]}"
+          fi
+
+          echo "Uploading only files changed since the remote git-ftp marker."
+          git ftp push "${COMMON_ARGS[@]}"
+          echo "Incremental deployment completed."


### PR DESCRIPTION
## Summary
- Restores normal Hostinger deployments to incremental `git ftp push` only.
- Removes the expensive `git ftp push --all` full upload path.
- Adds a one-time manual repair input `repair_deploy_marker_to_commit` so we can reset the remote git-ftp marker to the commit that is actually already deployed, then upload only files changed after that commit.
- Keeps `--disable-epsv` for Hostinger FTP compatibility.

## Why
The full upload attempted to buffer 3,669 files and failed after ~30 minutes. We do not need to re-upload the whole site. The correct fix is to repair the stale git-ftp marker caused by the earlier `catchup` workflow, then let `git ftp push` upload only the changed files.

## One-time repair run after merge
Run **Actions → Deploy to Hostinger → Run workflow**:

```text
Branch: main
repair_deploy_marker_to_commit: 2cd5e5c5f5577af41fb9bd12548347bab5599e78
```

Then the workflow will:

1. Set Hostinger `.git-ftp.log` to the known deployed base commit without uploading files.
2. Run normal `git ftp push`, uploading only files changed since that base.

## Steady-state behavior after repair
Future pushes do not need the input. They will run normal incremental deploys.

## Verification
- Workflow YAML parsed locally.
- `git diff --check` passed.
