### PR TITLE
Improve service page SEO intent

### DIFF
--- a/service-ai.html
+++ b/service-ai.html
@@ -10,13 +10,38 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <!-- End Google Tag Manager -->
   <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>AI & Machine Learning Services, DSaaS and Computer Vision — S.T.R.In.G</title>
-<meta name="description" content="AI and machine learning services: LLM agents, predictive models, DSaaS, computer vision, image analysis, NLP, document AI and MLOps." />
+<title>AI Automation & Machine Learning Services | StringLab</title>
+<meta name="description" content="Build production AI automation, LLM agents, computer vision, predictive models and MLOps systems with StringLab’s applied AI engineering team." />
 <meta name="robots" content="index, follow" />
-<meta property="og:title" content="AI & Machine Learning — S.T.R.In.G" />
-<meta property="og:description" content="LLM copilots, RAG agents, predictive models, CV pipelines and MLOps from a team that has shipped to production." />
+<meta property="og:title" content="AI Automation & Machine Learning Services | StringLab" />
+<meta property="og:description" content="Production AI automation, LLM copilots, RAG agents, computer vision and model monitoring for global teams." />
 <meta property="og:type" content="website" />
 <link rel="canonical" href="https://stringlab.org/service-ai" />
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Service",
+  "@id": "https://stringlab.org/service-ai#service",
+  "name": "AI automation and machine learning development",
+  "serviceType": "AI automation and machine learning development",
+  "description": "Production AI automation, LLM agents, RAG systems, computer vision, predictive models and MLOps services.",
+  "provider": {
+    "@type": "Organization",
+    "@id": "https://stringlab.org/#organization",
+    "name": "StringLab Technology Solutions",
+    "url": "https://stringlab.org/"
+  },
+  "areaServed": [
+    {"@type": "Country", "name": "India"},
+    {"@type": "Country", "name": "United States"},
+    {"@type": "Country", "name": "United Kingdom"},
+    {"@type": "City", "name": "Mumbai"},
+    {"@type": "City", "name": "Bengaluru"},
+    {"@type": "City", "name": "New York"}
+  ],
+  "url": "https://stringlab.org/service-ai"
+}
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;1,6..72,400&family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
@@ -35,8 +60,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <section class="pg-hero">
   <div class="container">
     <div class="crumbs"><a href="/">Home</a><span class="sep">/</span><a href="/services">Services</a><span class="sep">/</span> AI & Machine Learning</div>
-    <h1 class="display">Intelligence that<br/><em>ships</em> to production.</h1>
-    <p class="sub">LLM copilots, retrieval-augmented agents, predictive models, computer vision, image analysis, data science as a service and full MLOps. We build AI systems that run reliably in the real world — not just in notebooks.</p>
+    <h1 class="display">AI automation that<br/><em>ships</em> to production.</h1>
+    <p class="sub">LLM copilots, retrieval-augmented agents, predictive models, computer vision, document AI and full MLOps for teams that need reliable AI systems in production — not just prototypes.</p>
     <div class="meta-row">
       <div><span class="k">Practice lead</span><span class="v">Applied ML / LLM</span></div>
       <div><span class="k">Typical engagement</span><span class="v">6–16 weeks</span></div>

--- a/service-automation.html
+++ b/service-automation.html
@@ -10,13 +10,38 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <!-- End Google Tag Manager -->
   <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Workflow Automation Services — S.T.R.In.G</title>
-<meta name="description" content="CRM/ERP automation, RPA, document workflows, API orchestration and event-driven pipelines. Replace the manual layer — S.T.R.In.G." />
+<title>Workflow Automation & RPA Services | StringLab</title>
+<meta name="description" content="Workflow automation and RPA services for CRM, ERP, documents, APIs and event-driven operations that reduce manual work and errors." />
 <meta name="robots" content="index, follow" />
-<meta property="og:title" content="Workflow Automation — S.T.R.In.G" />
-<meta property="og:description" content="RPA, API orchestration, document automation and event-driven pipelines that eliminate repetitive manual work at scale." />
+<meta property="og:title" content="Workflow Automation & RPA Services | StringLab" />
+<meta property="og:description" content="CRM, ERP, RPA, document automation and API orchestration for teams replacing repetitive manual work." />
 <meta property="og:type" content="website" />
 <link rel="canonical" href="https://stringlab.org/service-automation" />
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Service",
+  "@id": "https://stringlab.org/service-automation#service",
+  "name": "Workflow automation and robotic process automation services",
+  "serviceType": "Workflow automation and robotic process automation services",
+  "description": "Workflow automation, RPA, CRM automation, ERP automation, document workflows and API orchestration services.",
+  "provider": {
+    "@type": "Organization",
+    "@id": "https://stringlab.org/#organization",
+    "name": "StringLab Technology Solutions",
+    "url": "https://stringlab.org/"
+  },
+  "areaServed": [
+    {"@type": "Country", "name": "India"},
+    {"@type": "Country", "name": "United States"},
+    {"@type": "Country", "name": "United Kingdom"},
+    {"@type": "City", "name": "Mumbai"},
+    {"@type": "City", "name": "Bengaluru"},
+    {"@type": "City", "name": "New York"}
+  ],
+  "url": "https://stringlab.org/service-automation"
+}
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;1,6..72,400&family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
@@ -35,8 +60,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <section class="pg-hero">
   <div class="container">
     <div class="crumbs"><a href="/">Home</a><span class="sep">/</span><a href="/services">Services</a><span class="sep">/</span> Workflow Automation</div>
-    <h1 class="display">Replace the<br/><em>manual</em> layer.</h1>
-    <p class="sub">CRM/ERP automation, RPA, document workflows, API orchestration and event-driven pipelines. We audit your process, automate what should never need a human, and give your team back time that compounds.</p>
+    <h1 class="display">Workflow automation that<br/><em>removes</em> manual work.</h1>
+    <p class="sub">CRM and ERP automation, RPA, document workflows, API orchestration and event-driven pipelines. We audit your process, automate repetitive work and build monitored systems your team can trust.</p>
     <div class="meta-row">
       <div><span class="k">Typical ROI horizon</span><span class="v">30–90 days</span></div>
       <div><span class="k">Avg. FTE hours saved</span><span class="v">60–80 hrs/month</span></div>

--- a/service-data.html
+++ b/service-data.html
@@ -10,13 +10,38 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <!-- End Google Tag Manager -->
   <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Data Analytics Services & Business Intelligence Solutions — S.T.R.In.G</title>
-<meta name="description" content="Data analytics services for BI, predictive analytics, dashboards, visualization, financial analytics, customer analytics and supply-chain insights." />
+<title>Data Analytics Consulting & BI Services | StringLab</title>
+<meta name="description" content="Data analytics consulting for BI dashboards, warehouses, pipelines, attribution, experimentation and governance that leadership can trust." />
 <meta name="robots" content="index, follow" />
-<meta property="og:title" content="Data & Analytics — S.T.R.In.G" />
-<meta property="og:description" content="Warehouses, pipelines, BI dashboards, experimentation and analytics that give leadership the numbers they can actually trust." />
+<meta property="og:title" content="Data Analytics Consulting & BI Services | StringLab" />
+<meta property="og:description" content="Warehouses, data pipelines, BI dashboards, attribution and data governance for decision-ready analytics." />
 <meta property="og:type" content="website" />
 <link rel="canonical" href="https://stringlab.org/service-data" />
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Service",
+  "@id": "https://stringlab.org/service-data#service",
+  "name": "Data analytics consulting and business intelligence services",
+  "serviceType": "Data analytics consulting and business intelligence services",
+  "description": "Data analytics consulting, BI dashboards, data warehouses, pipelines, attribution, experimentation and governance services.",
+  "provider": {
+    "@type": "Organization",
+    "@id": "https://stringlab.org/#organization",
+    "name": "StringLab Technology Solutions",
+    "url": "https://stringlab.org/"
+  },
+  "areaServed": [
+    {"@type": "Country", "name": "India"},
+    {"@type": "Country", "name": "United States"},
+    {"@type": "Country", "name": "United Kingdom"},
+    {"@type": "City", "name": "Mumbai"},
+    {"@type": "City", "name": "Bengaluru"},
+    {"@type": "City", "name": "New York"}
+  ],
+  "url": "https://stringlab.org/service-data"
+}
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;1,6..72,400&family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
@@ -35,8 +60,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <section class="pg-hero">
   <div class="container">
     <div class="crumbs"><a href="/">Home</a><span class="sep">/</span><a href="/services">Services</a><span class="sep">/</span> Data & Analytics</div>
-    <h1 class="display">Numbers the board<br/><em>actually</em> trust.</h1>
-    <p class="sub">Warehouses and pipelines, BI dashboards, experimentation, attribution and the governance work that keeps it honest. We build data infrastructure that your analysts love and your CFO signs off on.</p>
+    <h1 class="display">Data analytics your board<br/><em>actually</em> trusts.</h1>
+    <p class="sub">Data warehouses, pipelines, BI dashboards, experimentation, attribution and governance for teams that need trustworthy reporting, faster decisions and fewer spreadsheet debates.</p>
     <div class="meta-row">
       <div><span class="k">Typical scope</span><span class="v">8–20 weeks</span></div>
       <div><span class="k">Delivery</span><span class="v">Weekly data releases</span></div>

--- a/service-or.html
+++ b/service-or.html
@@ -10,13 +10,38 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <!-- End Google Tag Manager -->
   <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Operations Research, Optimization, Simulation & UI/UX Design — S.T.R.In.G</title>
-<meta name="description" content="Operations research services for optimization, simulation, routing, forecasting, decision analysis, supply chain, finance, retail and UI/UX design." />
+<title>Operations Research & Optimization Consulting | StringLab</title>
+<meta name="description" content="Operations research consulting for optimization, simulation, routing, scheduling, supply chain decisions and decision-support product design." />
 <meta name="robots" content="index, follow" />
-<meta property="og:title" content="Operations Research & Experience Design — S.T.R.In.G" />
-<meta property="og:description" content="OR modelling, supply-chain optimisation, simulation and UX design that turns complex decisions into clear, defensible answers." />
+<meta property="og:title" content="Operations Research & Optimization Consulting | StringLab" />
+<meta property="og:description" content="Optimization, simulation, routing, scheduling and decision-support systems for complex operations." />
 <meta property="og:type" content="website" />
 <link rel="canonical" href="https://stringlab.org/service-or" />
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Service",
+  "@id": "https://stringlab.org/service-or#service",
+  "name": "Operations research and optimization consulting",
+  "serviceType": "Operations research and optimization consulting",
+  "description": "Optimization, simulation, routing, scheduling, supply chain modelling and decision-support product design services.",
+  "provider": {
+    "@type": "Organization",
+    "@id": "https://stringlab.org/#organization",
+    "name": "StringLab Technology Solutions",
+    "url": "https://stringlab.org/"
+  },
+  "areaServed": [
+    {"@type": "Country", "name": "India"},
+    {"@type": "Country", "name": "United States"},
+    {"@type": "Country", "name": "United Kingdom"},
+    {"@type": "City", "name": "Mumbai"},
+    {"@type": "City", "name": "Bengaluru"},
+    {"@type": "City", "name": "New York"}
+  ],
+  "url": "https://stringlab.org/service-or"
+}
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;1,6..72,400&family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
@@ -35,8 +60,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <section class="pg-hero">
   <div class="container">
     <div class="crumbs"><a href="/">Home</a><span class="sep">/</span><a href="/services">Services</a><span class="sep">/</span> Operations Research & Design</div>
-    <h1 class="display">Science-backed<br/><em>operations</em>.</h1>
-    <p class="sub">Linear and nonlinear programming, simulation modeling, network optimization, decision analysis, forecasting, supply-chain optimization, plus UX research, product design and brand systems. The practice that turns your hardest trade-off decisions into defensible, optimized answers.</p>
+    <h1 class="display">Operations research for<br/><em>optimized</em> decisions.</h1>
+    <p class="sub">Linear and nonlinear programming, simulation modeling, network optimization, routing, scheduling, forecasting and decision-support design. We turn hard operational trade-offs into defensible, optimized answers.</p>
     <div class="meta-row">
       <div><span class="k">Methods</span><span class="v">MIP · Simulation · Heuristics</span></div>
       <div><span class="k">Typical ROI</span><span class="v">15–40% cost reduction</span></div>

--- a/service-product.html
+++ b/service-product.html
@@ -10,13 +10,38 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <!-- End Google Tag Manager -->
   <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Web & Application Development, SaaS and Product Engineering — S.T.R.In.G</title>
-<meta name="description" content="Custom web application development, mobile apps, e-commerce, SaaS dashboards, enterprise portals, APIs, cloud infrastructure, QA, support and product engineering." />
+<title>Custom Software & Web App Development | StringLab</title>
+<meta name="description" content="Custom software, web app development, SaaS dashboards, mobile apps, APIs and cloud infrastructure built by a senior product engineering team." />
 <meta name="robots" content="index, follow" />
-<meta property="og:title" content="Web, App & Product Engineering — S.T.R.In.G" />
-<meta property="og:description" content="Full-stack product engineering at weekly ship cadence. Next.js, React Native, iOS, Android, AR, DevOps and cloud infrastructure." />
+<meta property="og:title" content="Custom Software & Web App Development | StringLab" />
+<meta property="og:description" content="Full-stack product engineering for custom web apps, SaaS platforms, mobile apps, APIs, DevOps and cloud infrastructure." />
 <meta property="og:type" content="website" />
 <link rel="canonical" href="https://stringlab.org/service-product" />
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Service",
+  "@id": "https://stringlab.org/service-product#service",
+  "name": "Custom software and web application development",
+  "serviceType": "Custom software and web application development",
+  "description": "Custom software development, web application development, SaaS product engineering, mobile apps, APIs and cloud infrastructure services.",
+  "provider": {
+    "@type": "Organization",
+    "@id": "https://stringlab.org/#organization",
+    "name": "StringLab Technology Solutions",
+    "url": "https://stringlab.org/"
+  },
+  "areaServed": [
+    {"@type": "Country", "name": "India"},
+    {"@type": "Country", "name": "United States"},
+    {"@type": "Country", "name": "United Kingdom"},
+    {"@type": "City", "name": "Mumbai"},
+    {"@type": "City", "name": "Bengaluru"},
+    {"@type": "City", "name": "New York"}
+  ],
+  "url": "https://stringlab.org/service-product"
+}
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;1,6..72,400&family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
@@ -35,8 +60,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <section class="pg-hero">
   <div class="container">
     <div class="crumbs"><a href="/">Home</a><span class="sep">/</span><a href="/services">Services</a><span class="sep">/</span> Product Engineering</div>
-    <h1 class="display">Built to last.<br/><em>Shipped</em> weekly.</h1>
-    <p class="sub">Custom web apps, mobile apps, enterprise portals, e-commerce platforms, SaaS dashboards, AR experiences, APIs, cloud infrastructure and DevOps. We work in weekly sprint cadence — you see working software every Friday, not a status report.</p>
+    <h1 class="display">Custom software<br/><em>shipped</em> weekly.</h1>
+    <p class="sub">Custom web apps, SaaS dashboards, mobile apps, enterprise portals, e-commerce platforms, APIs, cloud infrastructure and DevOps. We work in weekly sprint cadence — you see working software, not just status reports.</p>
     <div class="meta-row">
       <div><span class="k">Ship cadence</span><span class="v">Weekly</span></div>
       <div><span class="k">Typical team size</span><span class="v">2–6 engineers</span></div>


### PR DESCRIPTION
## Summary
- Rewrites service-page titles, meta descriptions, Open Graph copy and H1s around commercial search intent.
- Adds `Service` JSON-LD schema to the five core service pages.
- Aligns area served with current SEO focus: India, United States, United Kingdom, Mumbai, Bengaluru and New York.

## Pages updated
- `/service-ai` — AI automation and machine learning services
- `/service-data` — data analytics consulting and BI services
- `/service-automation` — workflow automation and RPA services
- `/service-product` — custom software and web app development
- `/service-or` — operations research and optimization consulting

## Verification
- Parsed all added JSON-LD blocks successfully.
- Confirmed one `<h1>` tag per updated service page.
- Checked title and meta description lengths.
- `git diff --check` passed.

## Notes
- No visual layout or JS behavior changes.
- This is intentionally a conservative commercial-intent pass, not a broad rewrite.
