### PR TITLE
SEO: strengthen internal links and conversion routing

### DIFF
--- a/assets/partials.js
+++ b/assets/partials.js
@@ -38,12 +38,11 @@
         <div>
           <h5>Services</h5>
           <ul>
-            <li><a href="/service-ai">AI & Machine Learning</a></li>
-            <li><a href="/service-automation">Workflow Automation</a></li>
-            <li><a href="/service-data">Data & Analytics</a></li>
-            <li><a href="/service-product">Product Engineering</a></li>
-            <li><a href="/service-or">Operations Research</a></li>
-            <li><a href="/service-or">UI/UX & Design</a></li>
+            <li><a href="/service-ai">AI Automation Services</a></li>
+            <li><a href="/service-automation">Workflow Automation & RPA</a></li>
+            <li><a href="/service-data">Data Analytics Consulting</a></li>
+            <li><a href="/service-product">Custom Software Development</a></li>
+            <li><a href="/service-or">Operations Research Consulting</a></li>
           </ul>
         </div>
         <div>

--- a/assets/partials.min.js
+++ b/assets/partials.min.js
@@ -32,12 +32,11 @@
         <div>
           <h5>Services</h5>
           <ul>
-            <li><a href="/service-ai">AI & Machine Learning</a></li>
-            <li><a href="/service-automation">Workflow Automation</a></li>
-            <li><a href="/service-data">Data & Analytics</a></li>
-            <li><a href="/service-product">Product Engineering</a></li>
-            <li><a href="/service-or">Operations Research</a></li>
-            <li><a href="/service-or">UI/UX & Design</a></li>
+            <li><a href="/service-ai">AI Automation Services</a></li>
+            <li><a href="/service-automation">Workflow Automation & RPA</a></li>
+            <li><a href="/service-data">Data Analytics Consulting</a></li>
+            <li><a href="/service-product">Custom Software Development</a></li>
+            <li><a href="/service-or">Operations Research Consulting</a></li>
           </ul>
         </div>
         <div>

--- a/case-biomass.html
+++ b/case-biomass.html
@@ -135,6 +135,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     </div>
     <div style="margin-top: 40px; display: flex; gap: 16px;">
       <a href="/work" class="btn ghost" style="border-color: var(--line-d); color: var(--ink);">← All case studies</a>
+      <a href="/service-or" class="btn ghost" style="border-color: var(--line-d); color: var(--ink);">Operations research consulting</a>
     </div>
   </div>
 </section>

--- a/case-marex.html
+++ b/case-marex.html
@@ -143,6 +143,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     </div>
     <div style="margin-top: 60px; display: flex; gap: 16px;">
       <a href="/work" class="btn ghost" style="border-color: var(--line-d); color: var(--ink);">← All case studies</a>
+      <a href="/service-product" class="btn ghost" style="border-color: var(--line-d); color: var(--ink);">Custom software development</a>
       <a href="/solution-remit" class="btn ghost" style="border-color: var(--line-d); color: var(--ink);">See the Remit product</a>
       <a href="/book" class="btn primary">Work with us</a>
     </div>

--- a/case-nirmala.html
+++ b/case-nirmala.html
@@ -142,7 +142,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     </div>
     <div style="margin-top: 40px; display: flex; gap: 16px;">
       <a href="/work" class="btn ghost" style="border-color: var(--line-d); color: var(--ink);">← All case studies</a>
-      <a href="/service-product" class="btn ghost" style="border-color: var(--line-d); color: var(--ink);">Our AR/XR practice</a>
+      <a href="/service-product" class="btn ghost" style="border-color: var(--line-d); color: var(--ink);">Custom software and AR/XR development</a>
       <a href="/book" class="btn primary" style="color: var(--ink); background: var(--accent);">Work with us</a>
     </div>
   </div>

--- a/case-patanjali.html
+++ b/case-patanjali.html
@@ -144,6 +144,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     </div>
     <div style="margin-top: 60px; display: flex; gap: 16px;">
       <a href="/work" class="btn ghost" style="border-color: var(--line-d); color: var(--ink);">← All case studies</a>
+      <a href="/service-ai" class="btn ghost" style="border-color: var(--line-d); color: var(--ink);">AI forecasting services</a>
       <a href="/book" class="btn primary">Work with us on something similar</a>
     </div>
   </div>

--- a/case-retail.html
+++ b/case-retail.html
@@ -135,6 +135,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     </div>
     <div style="margin-top: 40px; display: flex; gap: 16px;">
       <a href="/work" class="btn ghost" style="border-color: var(--line-d); color: var(--ink);">← All case studies</a>
+      <a href="/service-or" class="btn ghost" style="border-color: var(--line-d); color: var(--ink);">Inventory optimization services</a>
     </div>
   </div>
 </section>

--- a/case-statista.html
+++ b/case-statista.html
@@ -115,7 +115,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="container">
     <div class="inline-cta">
       <h3>Need an AI agent that handles your support load?</h3>
-      <a href="/book" class="btn primary">Book a discovery call →</a>
+      <a href="/service-ai" class="btn ghost">AI automation services</a>
+      <a href="/book" class="btn primary">Book an AI discovery call →</a>
     </div>
   </div>
 </section>

--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
               "@type": "Offer",
               "itemOffered": {
                 "@type": "Service",
-                "name": "Workflow Automation"
+                "name": "Workflow Automation & RPA"
               }
             },
             {
@@ -2725,7 +2725,7 @@
             </p>
             <div class="sc-actions">
               <a href="/service-ai" class="btn primary"
-                >AI development services
+                >AI automation services
                 <svg class="arrow" viewBox="0 0 14 14" fill="none">
                   <path
                     d="M3 11L11 3M11 3H5M11 3V9"
@@ -2735,7 +2735,7 @@
                   />
                 </svg>
               </a>
-              <a href="/work" class="btn ghost">Case studies</a>
+              <a href="/case-statista" class="btn ghost">AI case study</a>
             </div>
           </div>
           <div class="sc-right">
@@ -2772,7 +2772,7 @@
               <span class="sc-num">02 / 05</span>
               <span class="sc-tag">Automation</span>
             </div>
-            <h3 class="sc-title">Workflow Automation.</h3>
+            <h3 class="sc-title">Workflow Automation & RPA.</h3>
             <p class="sc-body">
               Replace repetitive, manual tasks with drag-and-drop tools that
               streamline operations, save time, and reduce errors. Your ops
@@ -2780,7 +2780,7 @@
             </p>
             <div class="sc-actions">
               <a href="/service-automation" class="btn primary"
-                >business automation solutions
+                >workflow automation services
                 <svg class="arrow" viewBox="0 0 14 14" fill="none">
                   <path
                     d="M3 11L11 3M11 3H5M11 3V9"
@@ -2790,7 +2790,7 @@
                   />
                 </svg>
               </a>
-              <a href="/work" class="btn ghost">Case studies</a>
+              <a href="/contact" class="btn ghost">Discuss automation</a>
             </div>
           </div>
           <div class="sc-right">
@@ -2835,7 +2835,7 @@
             </p>
             <div class="sc-actions">
               <a href="/service-data" class="btn primary"
-                >Data &amp; Analytics Services
+                >data analytics consulting
                 <svg class="arrow" viewBox="0 0 14 14" fill="none">
                   <path
                     d="M3 11L11 3M11 3H5M11 3V9"
@@ -2845,7 +2845,7 @@
                   />
                 </svg>
               </a>
-              <a href="/work" class="btn ghost">Case studies</a>
+              <a href="/case-patanjali" class="btn ghost">Forecasting case study</a>
             </div>
           </div>
           <div class="sc-right">
@@ -2890,7 +2890,7 @@
             </p>
             <div class="sc-actions">
               <a href="/service-product" class="btn primary"
-                >See capability
+                >custom software development
                 <svg class="arrow" viewBox="0 0 14 14" fill="none">
                   <path
                     d="M3 11L11 3M11 3H5M11 3V9"
@@ -2900,7 +2900,7 @@
                   />
                 </svg>
               </a>
-              <a href="/work" class="btn ghost">Case studies</a>
+              <a href="/case-nirmala" class="btn ghost">Product case study</a>
             </div>
           </div>
           <div class="sc-right">
@@ -2945,7 +2945,7 @@
             </p>
             <div class="sc-actions">
               <a href="/service-or" class="btn primary"
-                >See capability
+                >operations research consulting
                 <svg class="arrow" viewBox="0 0 14 14" fill="none">
                   <path
                     d="M3 11L11 3M11 3H5M11 3V9"
@@ -2955,7 +2955,7 @@
                   />
                 </svg>
               </a>
-              <a href="/work" class="btn ghost">Case studies</a>
+              <a href="/case-biomass" class="btn ghost">Optimization case study</a>
             </div>
           </div>
           <div class="sc-right">
@@ -3857,11 +3857,11 @@
           <div>
             <h5>Services</h5>
             <ul>
-              <li><a href="/service-product">Web & App Development</a></li>
-              <li><a href="/service-ai">AI & Machine Learning</a></li>
-              <li><a href="/service-data">Data Analytics</a></li>
-              <li><a href="/service-automation">Automation</a></li>
-              <li><a href="/service-or">Operations Research & Design</a></li>
+              <li><a href="/service-ai">AI Automation Services</a></li>
+              <li><a href="/service-automation">Workflow Automation & RPA</a></li>
+              <li><a href="/service-data">Data Analytics Consulting</a></li>
+              <li><a href="/service-product">Custom Software Development</a></li>
+              <li><a href="/service-or">Operations Research Consulting</a></li>
             </ul>
           </div>
           <div>

--- a/services.html
+++ b/services.html
@@ -27,11 +27,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "@type": "ItemList",
   "name": "S.T.R.In.G technology services",
   "itemListElement": [
-    {"@type": "Service", "position": 1, "name": "AI and Machine Learning Services", "url": "https://stringlab.org/service-ai"},
-    {"@type": "Service", "position": 2, "name": "Workflow Automation Services", "url": "https://stringlab.org/service-automation"},
-    {"@type": "Service", "position": 3, "name": "Data Analytics Services", "url": "https://stringlab.org/service-data"},
-    {"@type": "Service", "position": 4, "name": "Web and App Development Services", "url": "https://stringlab.org/service-product"},
-    {"@type": "Service", "position": 5, "name": "Operations Research and UI/UX Design Services", "url": "https://stringlab.org/service-or"}
+    {"@type": "Service", "position": 1, "name": "AI Automation and Machine Learning Services", "url": "https://stringlab.org/service-ai"},
+    {"@type": "Service", "position": 2, "name": "Workflow Automation and RPA Services", "url": "https://stringlab.org/service-automation"},
+    {"@type": "Service", "position": 3, "name": "Data Analytics Consulting and BI Services", "url": "https://stringlab.org/service-data"},
+    {"@type": "Service", "position": 4, "name": "Custom Software and Web App Development", "url": "https://stringlab.org/service-product"},
+    {"@type": "Service", "position": 5, "name": "Operations Research and Optimization Consulting", "url": "https://stringlab.org/service-or"}
   ]
 }
 </script>
@@ -63,33 +63,33 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       
       <a href="/service-ai" class="card">
         <span class="num">01 · LLM · CV · MLOps</span>
-        <h3>AI & Machine Learning.</h3>
+        <h3>AI Automation & Machine Learning.</h3>
         <p>LLM copilots, retrieval-augmented agents, predictive models, computer vision and MLOps. Intelligent systems that actually ship.</p>
-        <span class="link">Capability brief →</span>
+        <span class="link">AI automation services →</span>
       </a>
       <a href="/service-automation" class="card">
         <span class="num">02 · RPA · APIs</span>
-        <h3>Workflow Automation.</h3>
+        <h3>Workflow Automation & RPA.</h3>
         <p>CRM/ERP automation, RPA, document workflows, API orchestration, event-driven pipelines. Replace the manual layer.</p>
-        <span class="link">Capability brief →</span>
+        <span class="link">Workflow automation services →</span>
       </a>
       <a href="/service-data" class="card">
         <span class="num">03 · dbt · Snowflake · BI</span>
-        <h3>Data & Analytics.</h3>
+        <h3>Data Analytics Consulting.</h3>
         <p>Warehouses and pipelines, BI dashboards, experimentation, attribution, and the governance work that keeps it honest.</p>
-        <span class="link">Capability brief →</span>
+        <span class="link">Data analytics consulting →</span>
       </a>
       <a href="/service-product" class="card">
         <span class="num">04 · Next.js · RN · AR</span>
-        <h3>Web, App & Product.</h3>
+        <h3>Custom Software & Web Apps.</h3>
         <p>Next.js, React Native, native iOS/Android, AR experiences, cloud infra and DevOps. Weekly ship cadence.</p>
-        <span class="link">Capability brief →</span>
+        <span class="link">Custom software development →</span>
       </a>
       <a href="/service-or" class="card">
         <span class="num">05 · OR · UX · Brand</span>
-        <h3>Operations Research & Design.</h3>
+        <h3>Operations Research & Optimization.</h3>
         <p>Linear programming, simulation, routing, forecasting, supply-chain optimization, plus UX research, product design and conversion-focused UI systems.</p>
-        <span class="link">Capability brief →</span>
+        <span class="link">Operations research consulting →</span>
       </a>
       <a href="/contact" class="card" style="background: var(--accent); color: var(--accent-ink); border-color: transparent;">
         <span class="num" style="color: rgba(11,11,12,0.7);">06 · Custom</span>
@@ -99,8 +99,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </a>
     </div>
     <div style="margin-top: 80px;" class="inline-cta">
-      <h3>Ready to see what a 30-min discovery call shakes loose?</h3>
-      <a href="/book" class="btn primary">Book a call →</a>
+      <h3>Ready to map the right service path?</h3>
+      <a href="/book" class="btn primary">Book a 30-min discovery call →</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- Strengthens homepage service CTAs with commercial anchor text and matching case-study routes.
- Updates Services page cards and JSON-LD service names for clearer intent alignment.
- Adds case-study back-links to relevant service pages.
- Aligns shared footer service links around the five core money pages.

## Verification
- Static verification passed for changed pages.
- JSON-LD parsed successfully.
- Internal href targets resolved to existing HTML routes.
- Expected commercial links were present on homepage, services, and case-study pages.
- `git diff --check` clean.

## SEO intent
Authority flow: homepage → service pages → case studies → booking/contact.
