### PR TITLE
fix(seo): redirect legacy indexed URLs

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -22,9 +22,16 @@ DirectoryIndex index.html index.php
   RewriteCond %{THE_REQUEST} \s/+index\.html[\s?] [NC]
   RewriteRule ^index\.html$ / [R=301,L]
 
-  # Legacy service URLs still receiving Search Console impressions.
-  RewriteRule ^data-analytics/?$ /service-data [R=301,L,NC]
-  RewriteRule ^image-analysis/?$ /service-ai [R=301,L,NC]
+  # Legacy URLs still receiving Search Console impressions or 404 coverage alerts.
+  # Consolidate old SEO surfaces into current canonical service/solution pages.
+  RewriteRule ^data-analytics(?:\.html)?/?$ /service-data [R=301,L,NC]
+  RewriteRule ^image-analysis(?:\.html)?/?$ /service-ai [R=301,L,NC]
+  RewriteRule ^use-case/financial-sentiment-analysis/?$ /service-ai [R=301,L,NC]
+  RewriteRule ^use-case/commodity-forecasting/?$ /solution-forecast [R=301,L,NC]
+  RewriteRule ^blogs/ai-in-business/?$ /service-ai [R=301,L,NC]
+  RewriteRule ^blogs/marketing-automation/?$ /service-automation [R=301,L,NC]
+  RewriteRule ^blogs/what-is-RAG/?$ /service-ai [R=301,L,NC]
+  RewriteRule ^pricing/?$ /book [R=301,L,NC]
 
   # Canonical extensioned page URLs to extensionless URLs.
   RewriteCond %{THE_REQUEST} \s/+(.+?)\.(html|php)[\s?] [NC]

--- a/Robots.txt
+++ b/Robots.txt
@@ -13,8 +13,9 @@ Disallow: /.local/
 Disallow: /.DS_Store
 Disallow: /stringlab.html
 
-# Crawl budget: keep bots focused on canonical pages and public assets
-Disallow: /*?*
+# Crawl budget: keep bots focused on canonical pages and public assets.
+# Do not blanket-block query URLs: legacy URLs such as /pricing/?country=in
+# need to be crawled so Google can see their 301 consolidation target.
 Allow: /assets/
 Allow: /sitemap.xml
 Allow: /robots.txt

--- a/robots.txt
+++ b/robots.txt
@@ -13,8 +13,9 @@ Disallow: /.local/
 Disallow: /.DS_Store
 Disallow: /stringlab.html
 
-# Crawl budget: keep bots focused on canonical pages and public assets
-Disallow: /*?*
+# Crawl budget: keep bots focused on canonical pages and public assets.
+# Do not blanket-block query URLs: legacy URLs such as /pricing/?country=in
+# need to be crawled so Google can see their 301 consolidation target.
 Allow: /assets/
 Allow: /sitemap.xml
 Allow: /robots.txt


### PR DESCRIPTION
## Summary
- Add explicit 301 redirects for legacy URLs still surfacing in Search Console 404/indexing reports.
- Consolidate old data/image/use-case/blog/pricing URLs into current canonical service, solution, and booking pages.
- Relax robots query-string blocking so Google can recrawl legacy query URLs such as `/pricing/?country=in` and observe the redirect.
- Keep lowercase `robots.txt` and uppercase `Robots.txt` consistent.

## Redirect map
| Legacy URL pattern | Destination |
|---|---|
| `/data-analytics`, `/data-analytics.html` | `/service-data` |
| `/image-analysis`, `/image-analysis.html` | `/service-ai` |
| `/use-case/financial-sentiment-analysis` | `/service-ai` |
| `/use-case/commodity-forecasting` | `/solution-forecast` |
| `/blogs/ai-in-business` | `/service-ai` |
| `/blogs/marketing-automation` | `/service-automation` |
| `/blogs/what-is-RAG` | `/service-ai` |
| `/pricing`, `/pricing/?country=in` | `/book` |

## Verification
- Redirect/robots static checks passed.
- `git diff --check` passed.
- Diff secret scan passed.

## Notes
- This is intentionally a focused cleanup PR before broader landing-page/content expansion.
- Reports/API credentials remain local and are not committed.
