### PR TITLE
seo: refresh sitemap lastmod for growth pages

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -44,19 +44,19 @@
   </url>
   <url>
     <loc>https://stringlab.org/case-patanjali</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://stringlab.org/case-retail</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://stringlab.org/case-statista</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -110,7 +110,7 @@
   </url>
   <url>
     <loc>https://stringlab.org/service-ai</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -122,7 +122,7 @@
   </url>
   <url>
     <loc>https://stringlab.org/service-data</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -134,13 +134,13 @@
   </url>
   <url>
     <loc>https://stringlab.org/service-product</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://stringlab.org/services</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>


### PR DESCRIPTION
## Summary
- Refresh `sitemap.xml` `<lastmod>` dates for pages changed in PR #35 and PR #36.
- Changed URLs:
  - `/services`
  - `/service-ai`
  - `/service-product`
  - `/service-data`
  - `/case-statista`
  - `/case-patanjali`
  - `/case-retail`

## Why
GSC URL Inspection shows these pages are indexed and crawlable, but some were last crawled before the growth-page updates. Updating precise sitemap `lastmod` entries gives Google a cleaner recrawl signal without changing URL structure.

## Verification
- XML parse passed.
- Live URL `200` checks passed for all changed sitemap entries.
- `git diff --check` passed.
- Diff secret scan passed.
