### PR TITLE
seo: enrich conversion page structured data

### DIFF
--- a/book.html
+++ b/book.html
@@ -10,13 +10,42 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <!-- End Google Tag Manager -->
   <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Book a Discovery Call — S.T.R.In.G</title>
-<meta name="description" content="Book a free 30-minute discovery call with the S.T.R.In.G team. No slides, no sales pitch — just a focused conversation about your problem." />
+<title>Book an AI, Data or Software Discovery Call | StringLab</title>
+<meta name="description" content="Book a 30-minute discovery call with StringLab for AI development, automation, data analytics or custom software. No sales deck — just practical scoping." />
 <meta name="robots" content="index, follow" />
-<meta property="og:title" content="Book a Discovery Call — S.T.R.In.G" />
+<meta property="og:title" content="Book an AI, Data or Software Discovery Call | StringLab" />
 <meta property="og:description" content="30 minutes. No sales deck. A focused conversation about your AI, automation or data challenge with the people who would actually work on it." />
 <meta property="og:type" content="website" />
 <link rel="canonical" href="https://stringlab.org/book" />
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "@id": "https://stringlab.org/book#webpage",
+  "url": "https://stringlab.org/book",
+  "name": "Book an AI, Data or Software Discovery Call",
+  "description": "Book a 30-minute discovery call with StringLab for AI development, workflow automation, data analytics, operations research or custom software development.",
+  "isPartOf": {"@id": "https://stringlab.org/#website"},
+  "about": {"@id": "https://stringlab.org/#organization"},
+  "potentialAction": {
+    "@type": "ScheduleAction",
+    "target": "https://cal.com/stringlab/quick-chat",
+    "name": "Schedule a 30-minute discovery call"
+  }
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {"@type": "Question", "name": "What happens on a StringLab discovery call?", "acceptedAnswer": {"@type": "Answer", "text": "You describe the business problem, current workflow, data or systems involved and what a good outcome looks like. StringLab gives an honest technical read and suggests next steps if there is a fit."}},
+    {"@type": "Question", "name": "Is the discovery call a sales pitch?", "acceptedAnswer": {"@type": "Answer", "text": "No. The call is designed to clarify the problem and identify whether AI, automation, data analytics or custom software is the right approach."}},
+    {"@type": "Question", "name": "Who joins the call?", "acceptedAnswer": {"@type": "Answer", "text": "A practice lead relevant to the problem joins the call, such as AI development, data analytics, workflow automation, operations research or product engineering."}}
+  ]
+}
+</script>
+
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;1,6..72,400&family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />

--- a/contact.html
+++ b/contact.html
@@ -10,10 +10,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <!-- End Google Tag Manager -->
   <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Contact S.T.R.In.G — AI, Data Science & Automation Experts in Mumbai</title>
-<meta name="description" content="Contact S.T.R.In.G for AI development, data science, automation, operations research, UI/UX design and custom software. Mumbai HQ: +91 97696 28463." />
+<title>Contact StringLab | AI, Data Analytics & Software Team in Mumbai</title>
+<meta name="description" content="Contact StringLab in Mumbai for AI development, data analytics consulting, workflow automation, operations research and custom software development." />
 <meta name="robots" content="index, follow" />
-<meta property="og:title" content="Contact S.T.R.In.G Technology Solutions" />
+<meta property="og:title" content="Contact StringLab Technology Solutions" />
 <meta property="og:description" content="Talk to our Mumbai-based AI, data science, automation and product engineering team about your next project." />
 <meta property="og:type" content="website" />
 <link rel="canonical" href="https://stringlab.org/contact" />
@@ -25,10 +25,22 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
-  "@type": "LocalBusiness",
+  "@type": ["LocalBusiness", "ProfessionalService"],
   "@id": "https://stringlab.org/#organization",
   "name": "S.T.R.In.G Technology Solutions",
   "url": "https://stringlab.org/contact",
+  "sameAs": ["https://stringlab.org/"],
+  "priceRange": "$$$",
+  "areaServed": [
+    {"@type": "Country", "name": "India"},
+    {"@type": "Country", "name": "United States"},
+    {"@type": "Country", "name": "United Kingdom"},
+    {"@type": "City", "name": "Mumbai"},
+    {"@type": "City", "name": "Bengaluru"},
+    {"@type": "City", "name": "New York"},
+    {"@type": "City", "name": "London"},
+    {"@type": "City", "name": "Singapore"}
+  ],
   "telephone": "+91-97696-28463",
   "email": "info@stringlab.org",
   "address": {
@@ -76,7 +88,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <section class="pg-hero">
   <div class="container">
     <div class="crumbs"><a href="/">Home</a><span class="sep">/</span> Contact</div>
-    <h1 class="display">Contact Stringlab AI &amp; Data Science Solutions.</h1>
+    <h1 class="display">Contact StringLab for AI, data analytics and software.</h1>
     <p class="sub">Get in touch with S.T.R.In.G for AI development, data science services, automation solutions, operations research, UI/UX design and custom software development. Whether you have a question, want a demo, or are ready to start your next project, our team will connect with you shortly.</p>
   </div>
 </section>
@@ -116,10 +128,10 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             <label for="interest">I'm interested in</label>
             <select id="interest" name="interest">
               <option value="">Select a practice area…</option>
-              <option>AI & Machine Learning</option>
+              <option>AI Development &amp; Automation</option>
               <option>Workflow Automation</option>
-              <option>Data & Analytics</option>
-              <option>Web, App & Product Engineering</option>
+              <option>Data Analytics Consulting</option>
+              <option>Custom Software Development</option>
               <option>Operations Research & Design</option>
               <option>One of your products (Digital Muneem / Remit / etc.)</option>
               <option>Something else — I'll explain below</option>

--- a/faq.html
+++ b/faq.html
@@ -10,13 +10,26 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <!-- End Google Tag Manager -->
   <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>FAQ — S.T.R.In.G</title>
-<meta name="description" content="Frequently asked questions about working with S.T.R.In.G — our process, pricing, team, technology choices and how engagements work." />
+<title>FAQ | Working with StringLab on AI, Data & Software</title>
+<meta name="description" content="Frequently asked questions about working with StringLab on AI development, automation, data analytics, custom software, pricing, process and delivery." />
 <meta name="robots" content="index, follow" />
-<meta property="og:title" content="FAQ — S.T.R.In.G" />
+<meta property="og:title" content="FAQ | Working with StringLab" />
 <meta property="og:description" content="Everything you wanted to know about working with S.T.R.In.G — process, pricing, team, tech and engagement models." />
 <meta property="og:type" content="website" />
 <link rel="canonical" href="https://stringlab.org/faq" />
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {"@type": "Question", "name": "What exactly does StringLab do?", "acceptedAnswer": {"@type": "Answer", "text": "StringLab builds AI development systems, workflow automation, data analytics platforms, custom software and operations research tools for businesses."}},
+    {"@type": "Question", "name": "How does an engagement typically start?", "acceptedAnswer": {"@type": "Answer", "text": "Every engagement starts with a 30-minute discovery call. If there is a fit, StringLab proposes a paid scoping engagement that produces a technical brief, architecture proposal and quote."}},
+    {"@type": "Question", "name": "Do clients own the code and IP?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. Code and IP produced for a client engagement belongs to the client, except for separately licensed proprietary product libraries if those are explicitly included."}},
+    {"@type": "Question", "name": "Do you handle data security and compliance?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. Security, privacy and compliance are scoped as first-class requirements for AI, data and software systems."}}
+  ]
+}
+</script>
+
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;1,6..72,400&family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
@@ -68,12 +81,12 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
       <details class="faq-item">
         <summary class="faq-q">What exactly does S.T.R.In.G do?<span class="faq-icon">+</span></summary>
-        <div class="faq-a"><p>We're a technical studio that builds AI, automation, data infrastructure and software products for companies across multiple industries. We work across five practices — AI & ML, Workflow Automation, Data & Analytics, Web/App/Product Engineering and Operations Research & Design.</p><p>We take on client projects (fixed-scope or retainer), and we also own and license a portfolio of products (Digital Muneem, Learning Engine, Remit, Forecast Kit, Stock Sense and Automated Document Reader).</p></div>
+        <div class="faq-a"><p>We're a technical studio that builds AI development systems, workflow automation, data analytics platforms, custom software and operations research tools for companies across multiple industries. We work across five practices — AI Development & Automation, Workflow Automation, Data Analytics Consulting, Custom Software Development and Operations Research & Optimization.</p><p>We take on client projects (fixed-scope or retainer), and we also own and license a portfolio of products (Digital Muneem, Learning Engine, Remit, Forecast Kit, Stock Sense and Automated Document Reader).</p></div>
       </details>
 
       <details class="faq-item">
         <summary class="faq-q">How big is the team?<span class="faq-icon">+</span></summary>
-        <div class="faq-a"><p>We're 28 FTE across two offices (Delhi and London), plus a vetted associate network of domain experts we draw on for specialised needs. We deliberately stay small enough that senior people do the work — not just scope it and hand it to juniors.</p></div>
+        <div class="faq-a"><p>We operate from Mumbai with a senior core team and a vetted associate network of domain experts for specialised needs. We deliberately stay small enough that senior people do the work — not just scope it and hand it to juniors.</p></div>
       </details>
 
       <details class="faq-item">


### PR DESCRIPTION
## Summary
- Strengthen `/book` title/meta and add WebPage + FAQPage JSON-LD for discovery-call conversion intent.
- Strengthen `/contact` title/meta, hero copy, practice-area options and LocalBusiness/ProfessionalService JSON-LD.
- Strengthen `/faq` title/meta, add FAQPage JSON-LD, and correct stale location/team wording to current Mumbai/global positioning.

## Why
After PRs #35–#37 improved commercial service pages and recrawl signals, this batch improves the conversion path that those pages drive traffic into: booking, contact and FAQ trust resolution.

## Verification
- `git diff --check` passed.
- Title/description/canonical checks passed.
- JSON-LD parsed successfully on changed pages.
- Diff secret scan passed.
- Local HTTP smoke test passed for `/book.html`, `/contact.html`, `/faq.html`.

## Scope control
No redesign, no form-handler changes, no analytics/report files, no secrets.