### PR TITLE
seo: refresh sitemap lastmod for conversion pages

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -14,7 +14,7 @@
   </url>
   <url>
     <loc>https://stringlab.org/book</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -62,7 +62,7 @@
   </url>
   <url>
     <loc>https://stringlab.org/contact</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -74,7 +74,7 @@
   </url>
   <url>
     <loc>https://stringlab.org/faq</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>


### PR DESCRIPTION
## Summary
- Refresh `sitemap.xml` `<lastmod>` for conversion pages changed in PR #38:
  - `/book`
  - `/contact`
  - `/faq`

## Why
PR #38 changed metadata, structured data, and conversion copy on these pages. Updating precise sitemap `lastmod` entries gives Google a clean recrawl signal.

## Verification
- XML parse passed.
- Live `200` checks passed for `/book`, `/contact`, `/faq`.
- `git diff --check` passed.
- Diff secret scan passed.
