### PR TITLE
seo: redirect remaining legacy demand URLs

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -31,6 +31,14 @@ DirectoryIndex index.html index.php
   RewriteRule ^blogs/ai-in-business/?$ /service-ai [R=301,L,NC]
   RewriteRule ^blogs/marketing-automation/?$ /service-automation [R=301,L,NC]
   RewriteRule ^blogs/what-is-RAG/?$ /service-ai [R=301,L,NC]
+  RewriteRule ^contact-our-team/?$ /contact [R=301,L,NC]
+  RewriteRule ^data-science/?$ /service-data [R=301,L,NC]
+  RewriteRule ^machine-learning/?$ /service-ai [R=301,L,NC]
+  RewriteRule ^operations-research/?$ /service-or [R=301,L,NC]
+  RewriteRule ^use-case/anomaly-detection/?$ /service-ai [R=301,L,NC]
+  RewriteRule ^use-case/inventory-management/?$ /solution-stocksense [R=301,L,NC]
+  RewriteRule ^use-case/routing-problem/?$ /service-or [R=301,L,NC]
+  RewriteRule ^ux/?$ /service-product [R=301,L,NC]
   RewriteRule ^pricing/?$ /book [R=301,L,NC]
 
   # Canonical extensioned page URLs to extensionless URLs.


### PR DESCRIPTION
## Summary
Consolidates additional legacy corporate URL demand still appearing in GSC into current canonical service/solution pages.

## Redirect map
| Legacy URL | Destination |
|---|---|
| `/contact-our-team` | `/contact` |
| `/data-science` | `/service-data` |
| `/machine-learning` | `/service-ai` |
| `/operations-research` | `/service-or` |
| `/use-case/anomaly-detection` | `/service-ai` |
| `/use-case/inventory-management` | `/solution-stocksense` |
| `/use-case/routing-problem` | `/service-or` |
| `/ux` | `/service-product` |

## Evidence
Latest GSC baseline still shows impressions on old corporate URL surfaces including `/data-analytics`, `/contact-our-team`, `/data-science`, `/machine-learning`, `/operations-research`, `/use-case/anomaly-detection`, `/use-case/inventory-management`, `/use-case/routing-problem`, and `/ux`. First batch redirects already cover `/data-analytics`, `/image-analysis`, `/financial-sentiment-analysis`, `/commodity-forecasting`, blog legacy URLs, and `/pricing`.

## Verification
- Redirect rules present in `.htaccess` before extension hiding rules.
- Live target pages return `200`.
- `git diff --check` passed.
- Diff secret scan passed.

## Scope control
- Corporate `stringlab.org` only.
- Does not alter `shine.stringlab.org` URLs, even though they appear separately in GSC segmentation.
- No content/template redesign.