### PR TITLE
ci: validate Autonomous SEO proposal branches

### DIFF
--- a/.github/workflows/autonomous-seo-validation.yml
+++ b/.github/workflows/autonomous-seo-validation.yml
@@ -24,22 +24,23 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Check patch formatting
-        run: git diff --check HEAD^ HEAD
-
-      - name: Find changed HTML files
-        id: changed-html
+      - name: Validate proposed SEO change
         shell: bash
         run: |
-          mapfile -t files < <(git diff-tree --no-commit-id --name-only -r HEAD -- '*.html')
+          set -euo pipefail
+          git diff --check HEAD^ HEAD
+
+          mapfile -d '' -t files < <(
+            git diff-tree --no-commit-id --name-only -r -z HEAD -- '*.html'
+          )
           if [ "${#files[@]}" -eq 0 ]; then
-            echo "files=" >> "$GITHUB_OUTPUT"
             echo "No changed HTML files require validation."
             exit 0
           fi
-          printf 'files=%s\n' "${files[*]}" >> "$GITHUB_OUTPUT"
-          printf 'Validating: %s\n' "${files[*]}"
 
-      - name: Validate changed HTML files
-        if: steps.changed-html.outputs.files != ''
-        run: npx --yes html-validate@9.4.2 ${{ steps.changed-html.outputs.files }}
+          for index in "${!files[@]}"; do
+            files[$index]="./${files[$index]}"
+          done
+
+          printf 'Validating: %s\n' "${files[*]}"
+          npx --yes html-validate@9.4.2 "${files[@]}"

--- a/.github/workflows/autonomous-seo-validation.yml
+++ b/.github/workflows/autonomous-seo-validation.yml
@@ -1,0 +1,45 @@
+name: Autonomous SEO validation
+
+on:
+  push:
+    branches:
+      - "autonomous-seo/validate-**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: autonomous-seo-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate proposed SEO change
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check patch formatting
+        run: git diff --check HEAD^ HEAD
+
+      - name: Find changed HTML files
+        id: changed-html
+        shell: bash
+        run: |
+          mapfile -t files < <(git diff-tree --no-commit-id --name-only -r HEAD -- '*.html')
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "files=" >> "$GITHUB_OUTPUT"
+            echo "No changed HTML files require validation."
+            exit 0
+          fi
+          printf 'files=%s\n' "${files[*]}" >> "$GITHUB_OUTPUT"
+          printf 'Validating: %s\n' "${files[*]}"
+
+      - name: Validate changed HTML files
+        if: steps.changed-html.outputs.files != ''
+        run: npx --yes html-validate@9.4.2 ${{ steps.changed-html.outputs.files }}


### PR DESCRIPTION
## Summary

- add a validation-only workflow for `autonomous-seo/validate-*` branches
- check patch formatting and validate only changed HTML files
- keep Hostinger deployment restricted to the existing `main` workflow

## Why

Autonomous SEO creates a temporary validation branch before opening its draft PR. The repository currently runs Actions only for `main`, so GitHub reports no check for the validation commit and the execution gate times out.

After this is merged, approve a new proposal version so the platform creates a new validation branch and receives this check result.

## Safety

- read-only `GITHUB_TOKEN` permission
- no deployment step
- validation is scoped to files changed by the proposal commit
